### PR TITLE
Inithook improvements

### DIFF
--- a/overlay/usr/lib/inithooks/bin/wireguard-server-init.sh
+++ b/overlay/usr/lib/inithooks/bin/wireguard-server-init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
-fatal() { echo "FATAL [$(basename $0)]: $@" 1>&2; exit 1; }
-info() { echo "INFO [$(basename $0)]: $@"; }
+fatal() { echo "FATAL [$(basename "$0")]: $*" 1>&2; exit 1; }
+info() { echo "INFO [$(basename "$0")]: $*"; }
 
 usage() {
     cat << EOF
@@ -25,7 +25,7 @@ domain="$2"
 WIREGUARD=/etc/wireguard
 
 for interface in $(wg show interfaces); do
-    wg-quick down $interface
+    wg-quick down "$interface"
 done
 rm -rf /etc/wireguard/*
 

--- a/overlay/usr/lib/inithooks/bin/wireguard.py
+++ b/overlay/usr/lib/inithooks/bin/wireguard.py
@@ -86,9 +86,15 @@ def main():
                 "Used in client configuration as wireguard endpoint",
                 "www.example.com")
 
+    inithooks_cache.write('APP_DOMAIN', domain)
+
     cmd = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                        'wireguard-server-init.sh')
-    subprocess.run([cmd, virtual_subnet, domain])
+    proc = subprocess.run([cmd, virtual_subnet, domain],
+                          capture_output=True,
+                          text=True)
+    if proc.returncode != 0:
+        fatal(f"command {' '.join(cmd)} failed.")
 
 
 if __name__ == '__main__':

--- a/overlay/usr/lib/inithooks/bin/wireguard.py
+++ b/overlay/usr/lib/inithooks/bin/wireguard.py
@@ -94,7 +94,8 @@ def main():
                           capture_output=True,
                           text=True)
     if proc.returncode != 0:
-        fatal(f"command {' '.join(cmd)} failed.")
+        fatal(f"command {' '.join(cmd)} failed:"
+              f"\n{sys.stderr}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There is an issue open regarding "Wireguard firstboot scripts should enable (or at least ask to enable) service" (see below).  after looking at [`wireguard-server-init.sh`](https://github.com/turnkeylinux-apps/wireguard/blob/master/overlay/usr/lib/inithooks/bin/wireguard-server-init.sh) - it actually does do that already!

I'm guessing that the reason why I opened the issue was that someone reported that it wasn't doing that. But that when the user ran the inithook it failed and returned a non-zero exit code, but because the exit code of the call to subprocess wasn't captured, it didn't actually give any feedback.

This isn't perfect, but should at least improve the situation.

Closes https://github.com/turnkeylinux/tracker/issues/1919