### PR TITLE
Another inithook tweak

### DIFF
--- a/overlay/usr/lib/inithooks/bin/wireguard.py
+++ b/overlay/usr/lib/inithooks/bin/wireguard.py
@@ -89,14 +89,19 @@ def main():
 
     inithooks_cache.write('APP_DOMAIN', domain)
 
+    # setup will fail if wg conf doesn't exist; it should but just in case...
+    wg0_conf = "/etc/wireguard/wg0.conf"
+    if not os.path.exists(wg0_conf):
+        open(wg0_conf, 'w').close()
+
     cmd = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                        'wireguard-server-init.sh')
     proc = subprocess.run([cmd, virtual_subnet, domain],
                           capture_output=True,
                           text=True)
     if proc.returncode != 0:
-        fatal(f"command {' '.join(cmd)} failed:"
-              f"\n{sys.stderr}")
+        fatal(f"command {cmd} failed:"
+              f"\n{proc.stderr}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Ensure that `/etc/wireguard/wg0.conf` exists - initialisation fails unless it exists; empty file is fine.
  - Note that `wg0.conf` _should_ always exist when the inithook runs, but it's best to not expect things to be "as they should be"!
- Fix broken error message if `wireguard-server-init.sh` fails - `cmd` is string and should be passing `proc.stderr`